### PR TITLE
Merge "Feature/most recent heatmap" into "dev"

### DIFF
--- a/application/controllers/nrlist.php
+++ b/application/controllers/nrlist.php
@@ -81,7 +81,8 @@ class Nrlist extends CI_Controller {
         $this->load->view('csv_view', $data);
     }
 
-    public function view($id, $nr_release_id)
+    public function view($id)
+    #public function view($id, $nr_release_id)
     {
         
         $this->output->cache(262974); # 6 months
@@ -125,7 +126,8 @@ class Nrlist extends CI_Controller {
         $this->table->set_heading('#S','PDB','Title','Method','Resolution','Length');
         $data['statistics'] = $this->table->generate($statistics);
 
-        $heatmap = $this->Nrlist_model->get_heatmap_data($id, $nr_release_id);
+        $heatmap = $this->Nrlist_model->get_heatmap_data($id);
+        #$heatmap = $this->Nrlist_model->get_heatmap_data($id, $nr_release_id);
         $data['heatmap_data'] = $heatmap;
         
         

--- a/application/models/nrlist_model.php
+++ b/application/models/nrlist_model.php
@@ -318,26 +318,32 @@ CREATE TABLE `nr_release_diff` (
        
 	}
 	
-	function get_heatmap_data($id, $release_id)
+	function get_heatmap_data($id)
+    #function get_heatmap_data($id, $release_id)
     {
-        echo "Incoming release_id: [" . $release_id . "]";
-
-        if(is_null($release_id)){
-            ### Look up the most recent release_id for the selected class
-
+        #echo "<p>Incoming release_id: [" . $release_id . "]</p>"; #DEBUG
+        #
+        #if(is_null($release_id)){
+        #    ### Look up the most recent release_id for the selected class
+        #
+        #    echo "<p>Looking up most recent release_id for class: [" . $id . "]</p>"; #DEBUG
+        #
             $this->db->select('NR.nr_release_id')
                      ->from('nr_classes AS NC')
                      ->join('nr_releases AS NR', 'NC.nr_release_id = NR.nr_release_id')
                      ->where('NC.name', $id)
-                     ->group_by('NC.name')
+                     #->group_by('NC.name')
                      ->order_by('NR.index', 'DESC')
                      ->limit(1);
             $result = $this->db->get()->result_array();
 
             $release_id = $result[0]['nr_release_id'];
-        }
-
-        echo "Updated release_id: [" . $release_id . "]";
+        #} else {
+        #    echo "<p>Have release_id already...</p>"; ### DEBUG
+        #}
+        #
+        #echo "<p>Updated release_id: [" . $release_id . "]</p>"; ### DEBUG
+        echo "<p>Release ID:  [" . $release_id . "]</p>"; ### DEBUG
 
         $this->db->distinct()
                  ->select('NC1.ife_id AS ife1')
@@ -361,6 +367,8 @@ CREATE TABLE `nr_release_diff` (
 
         $query = $this->db->get();
 
+        //  why do this processing if the results are not used?!?
+        /*
         foreach($query->result() as $row) {
             $ife1[] = $row->ife1;
             $ife1_index[] = $row->ife1_index;
@@ -368,11 +376,11 @@ CREATE TABLE `nr_release_diff` (
             $ife2_index[] = $row->ife2_index;
             $discrepancy[] = $row->discrepancy;
         }
+        */
 
         $heatmap_data = json_encode($query->result());
 
         return $heatmap_data;
-	
 	}
 
 
@@ -897,7 +905,8 @@ CREATE TABLE `nr_release_diff` (
 
             // $id refers to the release_id
             $table[] = array($i,
-                             anchor(base_url("nrlist/view/".$class_id."/".$id),$class_id,$id)
+                             anchor(base_url("nrlist/view/".$class_id),$class_id)
+                             #anchor(base_url("nrlist/view/".$class_id."/".$id),$class_id,$id)
                              . '<br>' . $this->add_annotation_label($row->nr_class_id, $reason)
                              . '<br>' . $source,
                              $ife_id . ' (<strong class="pdb">' . $pdb_id . '</strong>)' .

--- a/application/models/nrlist_model.php
+++ b/application/models/nrlist_model.php
@@ -320,6 +320,8 @@ CREATE TABLE `nr_release_diff` (
 	
 	function get_heatmap_data($id, $release_id)
     {
+        echo "Incoming release_id: [" . $release_id . "]";
+
         if(is_null($release_id)){
             ### Look up the most recent release_id for the selected class
 
@@ -334,6 +336,8 @@ CREATE TABLE `nr_release_diff` (
 
             $release_id = $result[0]['nr_release_id'];
         }
+
+        echo "Updated release_id: [" . $release_id . "]";
 
         $this->db->distinct()
                  ->select('NC1.ife_id AS ife1')

--- a/application/models/nrlist_model.php
+++ b/application/models/nrlist_model.php
@@ -319,31 +319,16 @@ CREATE TABLE `nr_release_diff` (
 	}
 	
 	function get_heatmap_data($id)
-    #function get_heatmap_data($id, $release_id)
     {
-        #echo "<p>Incoming release_id: [" . $release_id . "]</p>"; #DEBUG
-        #
-        #if(is_null($release_id)){
-        #    ### Look up the most recent release_id for the selected class
-        #
-        #    echo "<p>Looking up most recent release_id for class: [" . $id . "]</p>"; #DEBUG
-        #
-            $this->db->select('NR.nr_release_id')
-                     ->from('nr_classes AS NC')
-                     ->join('nr_releases AS NR', 'NC.nr_release_id = NR.nr_release_id')
-                     ->where('NC.name', $id)
-                     #->group_by('NC.name')
-                     ->order_by('NR.index', 'DESC')
-                     ->limit(1);
-            $result = $this->db->get()->result_array();
+        $this->db->select('NR.nr_release_id')
+                 ->from('nr_classes AS NC')
+                 ->join('nr_releases AS NR', 'NC.nr_release_id = NR.nr_release_id')
+                 ->where('NC.name', $id)
+                 ->order_by('NR.index', 'DESC')
+                 ->limit(1);
+        $result = $this->db->get()->result_array();
 
-            $release_id = $result[0]['nr_release_id'];
-        #} else {
-        #    echo "<p>Have release_id already...</p>"; ### DEBUG
-        #}
-        #
-        #echo "<p>Updated release_id: [" . $release_id . "]</p>"; ### DEBUG
-        echo "<p>Release ID:  [" . $release_id . "]</p>"; ### DEBUG
+        $release_id = $result[0]['nr_release_id'];
 
         $this->db->distinct()
                  ->select('NC1.ife_id AS ife1')

--- a/application/models/nrlist_model.php
+++ b/application/models/nrlist_model.php
@@ -319,8 +319,22 @@ CREATE TABLE `nr_release_diff` (
 	}
 	
 	function get_heatmap_data($id, $release_id)
-	
     {
+        if(is_null($release_id)){
+            ### Look up the most recent release_id for the selected class
+
+            $this->db->select('NR.nr_release_id')
+                     ->from('nr_classes AS NC')
+                     ->join('nr_releases AS NR', 'NC.nr_release_id = NR.nr_release_id')
+                     ->where('NC.name', $id)
+                     ->group_by('NC.name')
+                     ->order_by('NR.index', 'DESC')
+                     ->limit(1);
+            $result = $this->db->get()->result_array();
+
+            $release_id = $result[0]['nr_release_id'];
+        }
+
         $this->db->distinct()
                  ->select('NC1.ife_id AS ife1')
                  ->select('NO1.index AS ife1_index')


### PR DESCRIPTION
To simplify the heatmap query and minimize its impact on the database (and consequently the rest of the website), the following steps were taken.

1. Retrieve the most recent release_id associated with a given equivalence class, and retrieve the heatmap data for that release only.  This should reduce the database load considerably and prevent hanging heatmap queries.
2. Remove the release_id from the URL.  It was added (in dev and child branches only) to support release-based heatmaps, which is deprecated by point #1.  This will avoid propagation of multiple (essentially identical) pages in the website cache as well.
3. Deactivated (via comment block) a portion of code that appears to do work that is not subsequently used.

To be pulled into master as soon as feasible.