### PR TITLE
Merge pull-ss-devs into master

### DIFF
--- a/application/models/pdb_model.php
+++ b/application/models/pdb_model.php
@@ -14,6 +14,7 @@ class Pdb_model extends CI_Model {
 
     function get_all_pdbs()
     {
+        print "<p>get_all_pdbs</p>";
         $this->db->select('distinct(pdb_id)')
                  ->from('pdb_info');
         $query = $this->db->get();
@@ -25,6 +26,7 @@ class Pdb_model extends CI_Model {
 
     function get_recent_rna_containing_structures($num)
     {
+        print "<p>get_recent_rna_containing_structures</p>";
         $this->db->select('distinct(pdb_id)')
                  ->from('pdb_info')
                  ->order_by('release_date', 'desc')
@@ -38,6 +40,7 @@ class Pdb_model extends CI_Model {
 
     function get_latest_motif_assignments($pdb_id, $loop_type)
     {
+        print "<p>get_latest_motif_assignments</p>";
         // $loop_type = IL or HL
         $latest_release = $this->get_latest_motif_release($loop_type);
         
@@ -55,6 +58,7 @@ class Pdb_model extends CI_Model {
 
     function get_loops($pdb_id)
     {
+        print "<p>get_loops</p>";
         $loop_release_id = $this->get_latest_loop_release();
         $this->db->select('lq.loop_id')
                  ->select('lq.status')
@@ -117,17 +121,20 @@ class Pdb_model extends CI_Model {
 
     function make_reason_label($status)
     {
+        print "<p>make_reason_label</p>";
         return '<label class="label important">' . $this->qa_status[$status] . '</label>';
     }
 
     function get_checkbox($id, $nt_ids)
     {
+        print "<p>get_checkbox</p>";
         return "<label><input type='radio' id='{$id}' class='jmolInline' data-coord='{$id}'>{$id}</label>" .
         "<span class='loop_link'>" . anchor_popup("loops/view/{$id}", '&#10140;') . "</span>" ;
     }
 
     function get_latest_loop_release()
     {
+        print "<p>get_latest_loop_release</p>";
         $this->db->select('loop_release_id')
                  ->from('loop_releases')
                  ->order_by('date','desc')
@@ -139,6 +146,7 @@ class Pdb_model extends CI_Model {
 
     function pdb_exists($pdb_id)
     {
+        print "<p>pdb_exists</p>";
         // does BGSU RNA Site know about this structure?
         $this->db->select('pdb_id')
                  ->from('pdb_info')
@@ -163,6 +171,7 @@ class Pdb_model extends CI_Model {
 
     function pdb_is_annotated($pdb_id, $interaction_type)
     {
+        print "<p>pdb_is_annotated</p>";
         //$this->db->select('pdb_analysis_status_id')
         //         ->from('pdb_analysis_status')
         //         ->where('pdb_id', $pdb_id)
@@ -191,6 +200,7 @@ class Pdb_model extends CI_Model {
 
     function _get_unit_ids($pdb_id)
     {
+        print "<p>_get_unit_ids</p>";
     #    // get correspondences between old and new ids
     #    $this->db->select('old_id, unit_id')
     #             ->from('__pdb_unit_id_correspondence')
@@ -227,6 +237,7 @@ class Pdb_model extends CI_Model {
 
     function get_interactions($pdb_id, $interaction_type)
     {
+        print "<p>get_interactions</p>";
         $url_parameters = array('basepairs', 'stacking', 'basephosphate', 'baseribose');
         $db_fields      = array('f_lwbp', 'f_stacks', 'f_bphs', 'f_brbs');
         $header_values  = array('Base-pair', 'Base-stacking', 'Base-phosphate', 'Base-ribose');
@@ -301,6 +312,7 @@ class Pdb_model extends CI_Model {
 
     function get_general_info($pdb_id)
     {
+        print "<p>get_general_info</p>";
         //  QUERY NEEDS TO BE REWRITTEN
         //  NEEDS DATA FROM BOTH pdb_info and chain_info
         $this->db->select()
@@ -348,6 +360,7 @@ class Pdb_model extends CI_Model {
 
     function get_latest_nr_release($pdb_id)
     {
+        print "<p>get_latest_nr_release</p>";
         $this->db->select('nr_release_id')
                  ->from('nr_releases')
                  ->order_by('date', 'desc')
@@ -358,6 +371,7 @@ class Pdb_model extends CI_Model {
 
     function get_nrlist_info($pdb_id)
     {
+        print "<p>get_nrlist_info</p>";
         // get the latest nr release
         $data['latest_nr_release'] = $this->get_latest_nr_release($pdb_id);
 
@@ -387,6 +401,7 @@ class Pdb_model extends CI_Model {
 
     function get_loops_info($pdb_id)
     {
+        print "<p>get_loops_info</p>";
         $this->db->select('count(loop_id) as counts, type')
                  ->from('loop_info')
                  ->where('pdb_id', $pdb_id)
@@ -412,6 +427,7 @@ class Pdb_model extends CI_Model {
 
     function get_latest_motif_release($motif_type)
     {
+        print "<p>get_latest_motif_release</p>";
         $this->db->select('ml_release_id')
                  ->from('ml_releases')
                  ->order_by('date', 'desc')
@@ -425,6 +441,7 @@ class Pdb_model extends CI_Model {
 
     function get_motifs_info($pdb_id, $motif_type)
     {
+        print "<p>get_motifs_info</p>";
         $latest_release = $this->get_latest_motif_release($motif_type);
         // count motifs
         $this->db->select('count(distinct motif_id) as counts')
@@ -438,6 +455,7 @@ class Pdb_model extends CI_Model {
 
     function get_pairwise_info($pdb_id, $interaction)
     {
+        print "<p>get_pairwise_info</p>";
         $this->db->select("count($interaction)/2 as counts")
                  ->from('unit_pairs_interactions')
                  ->where('pdb_id', $pdb_id);
@@ -455,6 +473,7 @@ class Pdb_model extends CI_Model {
 
     function get_related_structures($pdb_id)
     {
+        print "<p>get_related_structures</p>";
         $pdb_id = strtoupper($pdb_id);
         $latest_nr_release = $this->get_latest_nr_release($pdb_id);
 
@@ -513,6 +532,7 @@ class Pdb_model extends CI_Model {
 
     function get_ordered_nts($pdb_id)
     {
+        print "<p>get_ordered_nts</p>";
         $this->db->select('ui.unit_id as id, ui.chain, ui.unit as sequence')
                  ->select_min('ui.sym_op')
                  ->from('unit_info AS ui')
@@ -533,13 +553,15 @@ class Pdb_model extends CI_Model {
             $chain_data[$row->chain]['nts'][] = array('id' => $row->id,
                                                       'sequence' => $row->sequence);
         }
-        
+
+        #print "<p>chain_data: " + var_dump($chain_data) + "</p>"; ### DEBUG
+
         return array_values($chain_data);
     }
 
     function get_airport($pdb_id)
     {
-        $table='pdb_airport';
+        $table = 'pdb_airport';
 
         if (! $this->db->table_exists($table)) {
             return false;
@@ -616,6 +638,7 @@ class Pdb_model extends CI_Model {
 
     function get_longrange_bp($pdb)
     {
+        print "<p>get_longrange_bp</p>";
         $this->db->select('U1.unit_id as nt1')
                  ->select('U2.unit_id as nt2')
                  ->select('upi.f_lwbp as family')

--- a/application/models/pdb_model.php
+++ b/application/models/pdb_model.php
@@ -594,7 +594,7 @@ class Pdb_model extends CI_Model {
 
             //  Revision:  performance of view ss_unit_positions is horrible, but
             //    the underlying query appears to perform better.
-            $this->db->select('UI.unit_id, SPM.pdb_id, UI.model, SPM.chain_name, UI.number')
+            $this->db->select('UI.unit_id, SPM.pdb_id, UI.model, SPM.chain_name AS chain, UI.number')
                      ->select('UI.unit, UI.alt_id, UI.ins_code, UI.sym_op, UI.chain_index')
                      ->select('UI.unit_type_id, SP.index, SP.ss_id, SP.x_coordinate')
                      ->select('SP.y_coordinate')

--- a/application/models/pdb_model.php
+++ b/application/models/pdb_model.php
@@ -226,59 +226,7 @@ class Pdb_model extends CI_Model {
     }
 
     function get_interactions($pdb_id, $interaction_type)
-    {   
-        if ( $interaction_type == 'baseaa' ) {
-
-            $unit_ids = $this->_get_unit_ids($pdb_id);
-
-            $this->db->select('uai.na_unit_id, uai.aa_unit_id, uai.annotation, uai.value')
-                 ->from('unit_aa_interactions AS uai')
-                 ->join('unit_info AS u1', 'uai.na_unit_id = u1.unit_id')
-                 ->join('unit_info AS u2', 'uai.aa_unit_id = u2.unit_id')
-                 ->where('uai.pdb_id', $pdb_id)
-                 #->order_by('number');
-                 ->order_by('u1.chain, u1.chain_index, u2.chain, u2.chain_index');
-            $query = $this->db->get();
-
-            foreach($query->result() as $row) {
-                $na_unit_id[] = $row->na_unit_id;
-                $aa_unit_id[] = $row->aa_unit_id;
-                $annotation[] = $row->annotation;
-                $value[] = $row->value;
-            }
-
-            $array_size = count($na_unit_id);
-
-            $html = '';
-
-            for ($i = 0; $i <= ($array_size-1); $i++) {
-
-                // Don't display value for cation-pi interactions
-                if ($value[$i] == NULL) {
-                
-                    $html .= str_pad('<span>' . $na_unit_id[$i] . '</span>', 38, ' ') .
-                             "<a class='jmolInline' id='s{$i}'>" .
-                             str_pad( '<span>' . $annotation[$i] . '</span>' , 10, '',STR_PAD_BOTH) .
-                             "</a>" .
-                             str_pad('<span>' . $aa_unit_id[$i] . '</span>', 38, ' ', STR_PAD_LEFT) .
-                             "\n";
-                } else {
-                    $html .= str_pad('<span>' . $na_unit_id[$i] . '</span>', 38, ' ') .
-                             "<a class='jmolInline' id='s{$i}'>" .
-                             str_pad( '<span>' . $annotation[$i] . '</span>', 10, '', STR_PAD_BOTH) .
-                             "</a>" .
-                             str_pad('<span>' . $aa_unit_id[$i] . '</span>', 38, ' ', STR_PAD_LEFT) .
-                             "\n";
-                }
-            }
-
-            return array( 'data'   => $html,
-                          'header' => array('#', 'Nucleotide id', 'Amino acid id', "Base-amino acid")
-                     );
-
-
-        } 
-
+    {
         $url_parameters = array('basepairs', 'stacking', 'basephosphate', 'baseribose');
         $db_fields      = array('f_lwbp', 'f_stacks', 'f_bphs', 'f_brbs');
         $header_values  = array('Base-pair', 'Base-stacking', 'Base-phosphate', 'Base-ribose');
@@ -499,17 +447,6 @@ class Pdb_model extends CI_Model {
         } else {
             $this->db->where("char_length($interaction) = 3");
         }
-
-        $result = $this->db->get()->row();
-
-        return number_format($result->counts, 0);
-    }
-
-    function get_baseaa_info($pdb_id)
-    {
-        $this->db->select("count(na_unit_id) as counts")
-                 ->from('unit_aa_interactions')
-                 ->where('pdb_id', $pdb_id);
 
         $result = $this->db->get()->row();
 

--- a/application/models/pdb_model.php
+++ b/application/models/pdb_model.php
@@ -616,33 +616,34 @@ class Pdb_model extends CI_Model {
             $model = '';
             $create = 0;
 
-        foreach ($query->result() as $row) {
-          $create = 1;
+            foreach ($query->result() as $row) {
+              $create = 1;
 
-          if ($row->unit_id){
-            $rowArr = array(
-              'y' => $row->y_coordinate,
-              'x' => $row->x_coordinate,
-              'id' => $row->unit_id,
-              'sequence' => $row->unit
-            );
+              if ($row->unit_id){
+                $rowArr = array(
+                  'y' => $row->y_coordinate,
+                  'x' => $row->x_coordinate,
+                  'id' => $row->unit_id,
+                  'sequence' => $row->unit
+                );
 
-            $nts_data[] = $rowArr;
-          }
+                $nts_data[] = $rowArr;
+              }
 
-          $model = !($model) ? $row->model : $model;
-        }
+              $model = !($model) ? $row->model : $model;
+            }
 
-        if ($create == 1) {
-          $new_json = array(
-              'nts'  => $nts_data,
-              'id'   => $row->pdb_id . '|' . $model . '|' . $row->chain,
-              'name' => 'Chain ' . $row->chain
-          );
+            if ($create == 1) {
+              $new_json = array(
+                  'nts'  => $nts_data,
+                  'id'   => $row->pdb_id . '|' . $model . '|' . $row->chain,
+                  'name' => 'Chain ' . $row->chain
+              );
 
-          #var_dump($new_json);
-          $new_result = '[' . json_encode($new_json, JSON_NUMERIC_CHECK) . ']';
-          #var_dump($new_result);
+              var_dump($new_json);
+              $new_result = '[' . json_encode($new_json, JSON_NUMERIC_CHECK) . ']';
+              var_dump($new_result);
+            }
         }
 
         $this->db->select('json_structure')

--- a/application/models/pdb_model.php
+++ b/application/models/pdb_model.php
@@ -635,14 +635,14 @@ class Pdb_model extends CI_Model {
 
             if ($create == 1) {
               $new_json = array(
-                  'nts'  => $nts_data,
-                  'id'   => $row->pdb_id . '|' . $model . '|' . $row->chain,
-                  'name' => 'Chain ' . $row->chain
+                'nts'  => $nts_data,
+                'id'   => $row->pdb_id . '|' . $model . '|' . $row->chain,
+                'name' => 'Chain ' . $row->chain
               );
 
-              var_dump($new_json);
+              #var_dump($new_json);
               $new_result = '[' . json_encode($new_json, JSON_NUMERIC_CHECK) . ']';
-              var_dump($new_result);
+              #var_dump($new_result);
             }
         }
 
@@ -650,10 +650,16 @@ class Pdb_model extends CI_Model {
                  ->from($table)
                  ->where('pdb_id', $pdb_id);
 
-        $result = $this->db->get()->row();
+        $query = $this->db->get();
+
+        if ( $query->num_rows() > 0 ) {
+          $result = $query->row();
+        } else {
+          $result = '';
+        }
 
         # DEBUG result sets
-        #/*
+        /*
         if ($new_result) {
           print "<p>NEW RESULT</p>";
           #return $new_result;
@@ -664,11 +670,9 @@ class Pdb_model extends CI_Model {
           print "<p>NO RESULTS</p>";
           #return false;
         }
-        #*/
+        */
 
         return ($new_result) ? $new_result : ($result) ? $result->json_structure : false;
-        #return ($new_result) ? $new_result : false;
-        #return ($result) ? $result->json_structure : false;
     }
 
     function get_longrange_bp($pdb)

--- a/application/models/pdb_model.php
+++ b/application/models/pdb_model.php
@@ -653,6 +653,7 @@ class Pdb_model extends CI_Model {
         $result = $this->db->get()->row();
 
         # DEBUG result sets
+        #/*
         if ($new_result) {
           print "<p>NEW RESULT</p>";
           #return $new_result;
@@ -663,6 +664,7 @@ class Pdb_model extends CI_Model {
           print "<p>NO RESULTS</p>";
           #return false;
         }
+        #*/
 
         return ($new_result) ? $new_result : ($result) ? $result->json_structure : false;
         #return ($new_result) ? $new_result : false;

--- a/application/models/pdb_model.php
+++ b/application/models/pdb_model.php
@@ -617,35 +617,46 @@ class Pdb_model extends CI_Model {
             $create = 0;
 
             foreach ($query->result() as $row) {
-              $create = 1;
+                $create = 1;
 
-              if ($row->unit_id){
-                $rowArr = array(
-                  'y' => $row->y_coordinate,
-                  'x' => $row->x_coordinate,
-                  'id' => $row->unit_id,
-                  'sequence' => $row->unit
-                );
+                if ($row->unit_id){
+                    $rowArr = array(
+                        'y' => $row->y_coordinate,
+                        'x' => $row->x_coordinate,
+                        'id' => $row->unit_id,
+                        'sequence' => $row->unit
+                    );
 
-                $nts_data[] = $rowArr;
-              }
+                    $nts_data[] = $rowArr;
+                }
 
-              $model = !($model) ? $row->model : $model;
+                $model = !($model) ? $row->model : $model;
             }
 
             if ($create == 1) {
-              $new_json = array(
-                'nts'  => $nts_data,
-                'id'   => $row->pdb_id . '|' . $model . '|' . $row->chain,
-                'name' => 'Chain ' . $row->chain
-              );
+                $new_json = array(
+                    'nts'  => $nts_data,
+                    'id'   => $row->pdb_id . '|' . $model . '|' . $row->chain,
+                    'name' => 'Chain ' . $row->chain
+                );
 
-              #var_dump($new_json);
-              $new_result = '[' . json_encode($new_json, JSON_NUMERIC_CHECK) . ']';
-              #var_dump($new_result);
+                #var_dump($new_json);
+                $new_result = '[' . json_encode($new_json, JSON_NUMERIC_CHECK) . ']';
+                #var_dump($new_result);
+
+                $json = $new_result;
             }
+        } else {
+            $this->db->select('json_structure')
+                     ->from($table)
+                     ->where('pdb_id', $pdb_id);
+
+            $result = $this->db->get()->row();
+
+            $json = ($result) ? $result->json_structure : "";
         }
 
+/*
         $this->db->select('json_structure')
                  ->from($table)
                  ->where('pdb_id', $pdb_id);
@@ -657,6 +668,7 @@ class Pdb_model extends CI_Model {
         } else {
           $result = '';
         }
+*/
 
         # DEBUG result sets
         /*
@@ -672,7 +684,8 @@ class Pdb_model extends CI_Model {
         }
         */
 
-        return ($new_result) ? $new_result : ($result) ? $result->json_structure : false;
+        return ($json) ? $json : false;
+        #return ($new_result) ? $new_result : ($result) ? $result->json_structure : false;
     }
 
     function get_longrange_bp($pdb)

--- a/application/models/pdb_model.php
+++ b/application/models/pdb_model.php
@@ -578,11 +578,43 @@ class Pdb_model extends CI_Model {
 
         $query = $this->db->get();
 
-        $nts_data = array();
-        $new_json = array();
-        $new_result = '';
-        $model = '';
-        $create = 0;
+        if ($query->num_rows()) {
+            // process ss_unit_positions
+
+            /*
+            //
+            //  First attempt to hack the new version, using ss_unit_positions.
+            //  This at least executes, even though I'm not doing anything
+            //    with the results.
+            //
+            $this->db->select()
+                     ->from('ss_unit_positions')
+                     ->where('pdb_id', $pdb_id);
+            */
+
+            //  Revision:  performance of view ss_unit_positions is horrible, but
+            //    the underlying query appears to perform better.
+            $this->db->select('UI.unit_id, SPM.pdb_id, UI.model, SPM.chain_name, UI.number')
+                     ->select('UI.unit, UI.alt_id, UI.ins_code, UI.sym_op, UI.chain_index')
+                     ->select('UI.unit_type_id, SP.index, SP.ss_id, SP.x_coordinate')
+                     ->select('SP.y_coordinate')
+                     ->select("IF(UI.unit_id IS NOT NULL, 1, 0) AS 'is_resolved'",false)
+                     ->from('ss_pdb_mapping AS SPM')
+                     ->join('ss_exp_seq_position_mapping AS ESPM', 'ESPM.ss_exp_seq_mapping_id = SPM.ss_exp_seq_mapping_id')
+                     ->join('ss_positions AS SP', 'SP.ss_position_id = ESPM.ss_position_id','left')
+                     ->join('exp_seq_unit_mapping AS ESUM','ESUM.exp_seq_position_id = ESPM.exp_seq_position_id','left')
+                     ->join('unit_info AS UI', 'UI.unit_id = ESUM.unit_id', 'left')
+                     ->where('ISNULL(UI.pdb_id)')
+                     ->or_where('UI.pdb_id = SPM.pdb_id')
+                     ->where('SPM.pdb_id', $pdb_id)
+                     ->group_by('SP.ss_position_id');
+;
+            $query = $this->db->get();
+
+            $nts_data = array();
+            $new_json = array();
+            $model = '';
+            $create = 0;
 
         foreach ($query->result() as $row) {
           $create = 1;


### PR DESCRIPTION
Branch pull-ss-devs contains updates to the get_airport() function that enable the airport viewer to operate against the ss_* tables in the database.

Backward compatibility is maintained for structures which only appear in the older pdb_airport table; data from ss_* will be used preferentially if present, and pdb_airport will only be queried when no structure is available in ss_*.

Output remains the JSON data required by the airport viewer.